### PR TITLE
refactoring

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -42,21 +42,21 @@ func toFloat64(v interface{}) (float64, bool) {
 	var f float64
 	flag := true
 	// as Go convert the json Numeric value to float64
-	switch v.(type) {
+	switch u := v.(type) {
 	case int:
-		f = float64(v.(int))
+		f = float64(u)
 	case int8:
-		f = float64(v.(int8))
+		f = float64(u)
 	case int16:
-		f = float64(v.(int16))
+		f = float64(u)
 	case int32:
-		f = float64(v.(int32))
+		f = float64(u)
 	case int64:
-		f = float64(v.(int64))
+		f = float64(u)
 	case float32:
-		f = float64(v.(float32))
+		f = float64(u)
 	case float64:
-		f = v.(float64)
+		f = u
 	default:
 		flag = false
 	}

--- a/jsonq.go
+++ b/jsonq.go
@@ -42,7 +42,7 @@ type JSONQ struct {
 	rootJSONContent interface{}          // original decoded json data
 	jsonContent     interface{}          // copy of original decoded json data for further processing
 	queryIndex      int                  // contains number of orWhere query call
-	queries         []([]query)          // nested queries
+	queries         [][]query            // nested queries
 	attributes      []string             // select attributes that will be available in final resuls
 	limitRecords    int                  // number of records that willbe available in final result
 	errors          []error              // contains all the errors when processing
@@ -268,7 +268,8 @@ func (j *JSONQ) findInMap(vm map[string]interface{}) []interface{} {
 	orPassed := false
 	for _, qList := range j.queries {
 		andPassed := true
-		for _, q := range qList {
+		for idx := 0; idx < len(qList); idx++ {
+			q := qList[idx]
 			cf, ok := j.queryMap[q.operator]
 			if !ok {
 				j.addError(fmt.Errorf("invalid operator %s", q.operator))


### PR DESCRIPTION
Fixed warnings which was found by [go-critic linter](https://github.com/go-critic/go-critic)

Corresponding log:  

> check-package: $GOPATH\src\github.com\thedevsaddam\gojsonq\helper.go:45:2: typeS
> witchVar: case 0 can benefit from type switch with assignment
> check-package: $GOPATH\src\github.com\thedevsaddam\gojsonq\helper.go:45:2: typeS
> witchVar: case 1 can benefit from type switch with assignment
> check-package: $GOPATH\src\github.com\thedevsaddam\gojsonq\helper.go:45:2: typeS
> witchVar: case 2 can benefit from type switch with assignment
> check-package: $GOPATH\src\github.com\thedevsaddam\gojsonq\helper.go:45:2: typeS
> witchVar: case 3 can benefit from type switch with assignment
> check-package: $GOPATH\src\github.com\thedevsaddam\gojsonq\helper.go:45:2: typeS
> witchVar: case 4 can benefit from type switch with assignment
> check-package: $GOPATH\src\github.com\thedevsaddam\gojsonq\helper.go:45:2: typeS
> witchVar: case 5 can benefit from type switch with assignment
> check-package: $GOPATH\src\github.com\thedevsaddam\gojsonq\helper.go:45:2: typeS
> witchVar: case 6 can benefit from type switch with assignment
> check-package: $GOPATH\src\github.com\thedevsaddam\gojsonq\jsonq.go:271:3: range
> ValCopy: each iteration copies 48 bytes (consider pointers or indexing)
> check-package: $GOPATH\src\github.com\thedevsaddam\gojsonq\jsonq.go:45:18: typeU
> nparen: could simplify []([]query) to [][]query