### PR TITLE
Add Out method issue #29

### DIFF
--- a/jsonq.go
+++ b/jsonq.go
@@ -578,6 +578,18 @@ func (j *JSONQ) Count() int {
 	return lnth
 }
 
+// Out write the queried data to defined custom type
+func (j *JSONQ) Out(v interface{}) {
+	data, err := json.Marshal(j.jsonContent)
+	if err != nil {
+		j.addError(err)
+		return
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		j.addError(err)
+	}
+}
+
 // getFloatValFromArray returns a list of float64 values from array/map for aggregation
 func (j *JSONQ) getFloatValFromArray(arr []interface{}, property ...string) []float64 {
 	ff := []float64{}

--- a/jsonq_test.go
+++ b/jsonq_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"reflect"
 	"strings"
 	"testing"
@@ -881,6 +882,54 @@ func TestJSONQ_Count_expecting_int_from_objects(t *testing.T) {
 	out := jq.Count()
 	expected := `5`
 	assertJSON(t, out, expected, "Count expecting a int number of total item of an array of grouped objects")
+}
+
+func TestJSONQ_Out_expecting_result(t *testing.T) {
+	type item struct {
+		ID    int    `json:"id"`
+		Name  string `json:"name"`
+		Price int    `json:"price"`
+	}
+	exptItm := item{
+		ID:    1,
+		Name:  "MacBook Pro 13 inch retina",
+		Price: 1350,
+	}
+	itm := item{}
+	jq := New().JSONString(jsonStr).
+		From("vendor.items.[0]")
+	jq.Out(&itm)
+	assertInterface(t, exptItm, itm, "failed to get Out result")
+}
+
+func TestJSONQ_Out_expecting_decoding_error(t *testing.T) {
+	type item struct {
+		ID    bool   `json:"id"`
+		Name  string `json:"name"`
+		Price int    `json:"price"`
+	}
+	itm := item{}
+	jq := New().JSONString(jsonStr).
+		From("vendor.items.[0]")
+	jq.Out(&itm)
+	if jq.Error() == nil {
+		t.Errorf("failed to get Out decoding error: %v", jq.Error())
+	}
+}
+
+func TestJSONQ_Out_expecting_encoding_error(t *testing.T) {
+	type item struct {
+		ID    bool   `json:"id"`
+		Name  string `json:"name"`
+		Price int    `json:"price"`
+	}
+	itm := item{}
+	jq := New()
+	jq.jsonContent = math.Inf(1)
+	jq.Out(&itm)
+	if jq.Error() == nil {
+		t.Errorf("failed to get Out encoding error: %v", jq.Error())
+	}
 }
 
 func TestJSONQ_Sum_of_array_numeric_values(t *testing.T) {

--- a/jsonq_testdata_test.go
+++ b/jsonq_testdata_test.go
@@ -1,5 +1,3 @@
-//
-
 package gojsonq
 
 import (


### PR DESCRIPTION
Usages Code of `Out` method:

```go
package main

import (
	"github.com/davecgh/go-spew/spew"
	"github.com/thedevsaddam/gojsonq"
)

type item struct {
	ID    int     `json:"id"`
	Name  string  `json:"name"`
	Price float64 `json:"price"`
}

func main() {
	v := item{}
	jq := gojsonq.New().File("./data.json").From("items.[0]")
	jq.Out(&v)
	if jq.Error() != nil {
		panic(jq.Error())
	}
	spew.Dump(v)
}

// Output:
// (main.item) {
//  ID: (int) 1,
//  Name: (string) (len=26) "MacBook Pro 13 inch retina",
//  Price: (float64) 1350
// }

```