### PR TITLE
add handling of objects to processQuery

### DIFF
--- a/jsonq.go
+++ b/jsonq.go
@@ -342,6 +342,9 @@ func (j *JSONQ) processQuery() *JSONQ {
 	if aa, ok := j.jsonContent.([]interface{}); ok {
 		j.jsonContent = j.findInArray(aa)
 	}
+	if obj, ok := j.jsonContent.(map[string]interface{}); ok {
+		j.jsonContent = j.findInMap(obj)
+	}
 	return j
 }
 

--- a/jsonq_test.go
+++ b/jsonq_test.go
@@ -384,6 +384,16 @@ func TestJSONQ_Where_multiple_where_with_invalid_operand_expecting_error(t *test
 	}
 }
 
+func TestJSONQ_Where_standalone_object(t *testing.T) {
+	jq := New().JSONString(jsonStr).
+		Where("name", "eq", "computers").
+		Where("vendor.website", "eq", "www.example.com")
+	expected := `[{"name":"Star Trek"}]`
+	out := jq.Select("vendor.name").Get()
+	assertJSON(t, out, expected, "multiple Where on object")
+}
+
+
 func TestJSONQ_single_WhereEqual(t *testing.T) {
 	jq := New().JSONString(jsonStr).
 		From("vendor.items").


### PR DESCRIPTION
Change to enable queries on standalone objects.   This makes queries like this possible:

```
j := gojsonq.New().JSONString(`{"name":{"first":"Tom","last":"Hanks"},"age":61}`)
ct := j.Where("age", ">=", 60).Where("name.last", "eq", "Hanks").Count() // 1
```