### PR TITLE
Add more error info on As() function

### DIFF
--- a/result.go
+++ b/result.go
@@ -57,9 +57,9 @@ func (r *Result) As(v interface{}) error {
 			"*[]float32": "Float32Slice", "*[]float64": "Float64Slice",
 		}
 
-        if methodMap[method] == "" {
-            panic(fmt.Sprintf("The method '%v' must be part of '%v'", method, methodMap))
-        }
+		if methodMap[method] == "" {
+			panic(fmt.Sprintf("The method '%v' must be part of '%v'", method, methodMap))
+		}
 
 		vv := reflect.ValueOf(r).MethodByName(methodMap[method]).Call(nil)
 		if vv != nil {

--- a/result.go
+++ b/result.go
@@ -57,6 +57,10 @@ func (r *Result) As(v interface{}) error {
 			"*[]float32": "Float32Slice", "*[]float64": "Float64Slice",
 		}
 
+        if methodMap[method] == "" {
+            panic(fmt.Sprintf("The method '%v' must be part of '%v'", method, methodMap))
+        }
+
 		vv := reflect.ValueOf(r).MethodByName(methodMap[method]).Call(nil)
 		if vv != nil {
 			if vv[1].Interface() != nil {


### PR DESCRIPTION
## issue
When using : 
```golang
tempTags = []Tag{} // Structure
jsonResult.As(&tempTags)
```
This error is displayed an error from reflect library: 
```
panic: reflect: call of reflect.Value.Call on zero Value [recovered]
        panic: reflect: call of reflect.Value.Call on zero Value
```

## Expected
Should display a more specific error that give us more clues in order to understand what is going on

```
Panic: the method '*[]repository.Tag' must be part of 'map[*[]bool:BoolSlice *[]float32:Float32Slice *[]float64:Float64Slice *[]int:IntSlice *[]int16:Int16Slice *[]int32:Int32Slice *[]int8:Int8Slice *[]string:StringSlice *[]time.Duration:DurationSlice *[]uint:UintSlice *[]uint16:Uint16Slice *[]uint32:Uint32Slice *[]uint8:Uint8Slice *bool:Bool *float32:Float32 *float64:Float64 *int:Int *int16:Int16 *int32:Int32 *int8:Int8 *string:String *time.Duration:Duration *uint:Uint *uint16:Uint16 *uint32:Uint32 *uint8:Uint8]' [recovered]
        panic: the method '*[]repository.Tag' must be part of 'map[*[]bool:BoolSlice *[]float32:Float32Slice *[]float64:Float64Slice *[]int:IntSlice *[]int16:Int16Slice *[]int32:Int32Slice *[]int8:Int8Slice *[]string:StringSlice *[]time.Duration:DurationSlice *[]uint:UintSlice *[]uint16:Uint16Slice *[]uint32:Uint32Slice *[]uint8:Uint8Slice *bool:Bool *float32:Float32 *float64:Float64 *int:Int *int16:Int16 *int32:Int32 *int8:Int8 *string:String *time.Duration:Duration *uint:Uint *uint16:Uint16 *uint32:Uint32 *uint8:Uint8]'
```